### PR TITLE
snap: fix autostart not working

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,7 @@ apps:
     extensions: [gnome]
     desktop: usr/share/applications/element-desktop.desktop
     command: launcher
+    autostart: element-desktop.desktop
     plugs:
       - shmem
       - camera


### PR DESCRIPTION
The fixes the autostart feature in the app, which places the `element-desktop.desktop` under `.config/autostart`.

